### PR TITLE
Add Lark badge and update volume widget

### DIFF
--- a/sketchybar/items/apple.lua
+++ b/sketchybar/items/apple.lua
@@ -23,14 +23,5 @@ local apple = sbar.add("item", {
   click_script = "$CONFIG_DIR/helpers/menus/bin/menus -s 0",
 })
 
--- Double border for apple using a single item bracket
-sbar.add("bracket", { apple.name }, {
-  background = {
-    color = colors.transparent,
-    height = 30,
-    border_color = colors.grey,
-  },
-})
-
 -- Padding item required because of bracket
 sbar.add("item", { width = 7 })

--- a/sketchybar/items/badges/init.lua
+++ b/sketchybar/items/badges/init.lua
@@ -1,2 +1,3 @@
 require "items.badges.wechat"
 require "items.badges.mail"
+require "items.badges.lark"

--- a/sketchybar/items/badges/lark.lua
+++ b/sketchybar/items/badges/lark.lua
@@ -1,0 +1,43 @@
+local colors = require "colors"
+local icons = require "icons"
+local settings = require "settings"
+local app_icons = require "helpers.app_icons"
+
+local lark = sbar.add("item", "badges.lark", {
+  position = "right",
+  padding_left = 0,
+  padding_right = 0,
+  icon = {
+    string = app_icons["Slack"],
+    font = "sketchybar-app-font:Regular:16.0",
+    color = colors.blue,
+    drawing = false,
+  },
+  label = {
+    font = { family = settings.font.numbers },
+    drawing = false,
+  },
+  update_freq = 10,
+  click_script = "open -a Lark",
+})
+
+lark:subscribe({ "forced", "routine", "system_woke" }, function(env)
+  sbar.exec("sh $CONFIG_DIR/utils/get-app-badge.sh Feishu", function(result, error)
+    local badge = result:match "^%s*(.-)%s*$"
+    if badge == "?" or badge == "0" then
+      lark:set {
+        padding_left = 0,
+        padding_right = 0,
+        icon = { drawing = false },
+        label = { drawing = false },
+      }
+    else
+      lark:set {
+        padding_left = 5,
+        padding_right = 5,
+        icon = { drawing = true },
+        label = { drawing = true, string = result },
+      }
+    end
+  end)
+end)

--- a/sketchybar/items/widgets/volume.lua
+++ b/sketchybar/items/widgets/volume.lua
@@ -8,6 +8,7 @@ local volume_percent = sbar.add("item", "widgets.volume1", {
   position = "right",
   icon = { drawing = false },
   label = {
+    width = 0,
     string = "??%",
     padding_left = -1,
     font = { family = settings.font.numbers },
@@ -44,6 +45,24 @@ local volume_bracket = sbar.add("bracket", "widgets.volume.bracket", {
   background = { color = colors.bg1 },
   popup = { align = "center" },
 })
+
+local function animate_volume_level(show_animation)
+  sbar.animate("tanh", 30, function()
+    if show_animation then
+      volume_percent:set { label = { width = "dynamic" } }
+    else
+      volume_percent:set { label = { width = 0 } }
+    end
+  end)
+end
+
+volume_bracket:subscribe("mouse.entered", function()
+  animate_volume_level(true)
+end)
+
+volume_bracket:subscribe("mouse.exited", function()
+  animate_volume_level(false)
+end)
 
 sbar.add("item", "widgets.volume.padding", {
   position = "right",


### PR DESCRIPTION
Adds a new badge for Lark to the status bar, which displays notifications 
based on the app's badge count. The badge updates every 10 seconds and 
opens the Lark application when clicked. 

Removes the double border bracket for the Apple item to simplify the 
layout and adds animation to the volume widget for better user 
experience when hovering.