### PR TITLE
Remove unused key mappings in mappings.lua

### DIFF
--- a/nvim/lua/mappings.lua
+++ b/nvim/lua/mappings.lua
@@ -4,14 +4,9 @@ require "nvchad.mappings"
 
 local del = vim.keymap.del
 
-del("n", "<Leader>/")
-del("v", "<Leader>/")
-
 del("n", "<Leader>n")
 del("n", "<Leader>rn")
 
-del("n", "<C-n>")
-del("n", "<leader>e")
 -- Set Keybindings
 
 local map = vim.keymap.set


### PR DESCRIPTION
Remove unused key mappings for search and navigation to 
clean up the configuration.